### PR TITLE
Update README.md to make `nui` sound less optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Easy setup and extra features for the native LSP client and the Idris2 LSP serve
 - `nvim-lspconfig`
 - `idris2`
 - `idris2-lsp`
-- `nui.nvim` (only for extra UI features)
+- `nui.nvim` (for UI features)
 
 ## Installation
 


### PR DESCRIPTION
This is pretty minor, but I found that someone I was working with on a PR interpreted `nui` as an optional requirement when in reality it is almost if not totally impossible to avoid `nui` when configuring/using this plugin.